### PR TITLE
make WorkspaceEntries collapsable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@formkit/auto-animate": "^0.7.0",
     "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.10.4",
     "@vercel/analytics": "^1.0.1",

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -145,7 +145,8 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
   const state = useContext(AppState);
 
   const [ expanded, setExpanded ] = useState(true);
-  const [ animParent, _ ] = useAutoAnimate();
+  const [ animTitleText, _ ] = useAutoAnimate();
+  const [ animEntryTools, __ ] = useAutoAnimate();
 
   let className = "workspace-entry";
   className += course.locked
@@ -168,15 +169,15 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
           >
-          <div className={`relative flex w-full justify-between`} ref={animParent} >
-            {expanded ? <div /> : <></>}
-            <div className="flex left-0 grow flex-initial" >
+          <div className={`relative w-full whitespace-nowrap`} ref={animEntryTools} >
+            <div className="left-0 w-min inline-block" >
               <IconButton  onClick={() => { setExpanded(!expanded); }}>
                 { expanded ? <UnfoldLess /> : <UnfoldMore /> }
               </IconButton>
-              { expanded ? <></> : <div className="font-bold flex items-center overflow-clip w-0 flex-grow whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
             </div>
-            <div className={`workspace-entry-buttons${expanded ? '' : '-collapsed'} right-0`} >
+            { expanded ? <></> : <div className="font-bold inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
+            <div className={`${expanded ? 'w-[calc(100%-2.5rem)]' : 'w-min'} inline-block top-auto bottom-0 right-0 left-auto`} >
+              <div className="workspace-entry-buttons">
 
               <Switch
                 color="warning"
@@ -207,6 +208,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
               >
                 <Delete />
               </IconButton>
+            </div>
             </div>
           </div>
           <Collapse in={expanded}>

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -145,8 +145,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
   const state = useContext(AppState);
 
   const [ expanded, setExpanded ] = useState(true);
-  const [ animTitleText, _ ] = useAutoAnimate();
-  const [ animEntryTools, __ ] = useAutoAnimate();
+  const [ collapseAnimation, __ ] = useAutoAnimate();
 
   let className = "workspace-entry";
   className += course.locked
@@ -169,7 +168,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
           >
-          <div className={`relative w-full whitespace-nowrap`} ref={animEntryTools} >
+          <div className={`relative w-full whitespace-nowrap`} ref={collapseAnimation} >
             <div className="left-0 w-min align-middle inline-block" >
               <IconButton  onClick={() => { setExpanded(!expanded); }}>
                 { expanded ? <UnfoldLess /> : <UnfoldMore /> }

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -170,13 +170,13 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             {...provided.dragHandleProps}
           >
           <div className={`relative w-full whitespace-nowrap`} ref={animEntryTools} >
-            <div className="left-0 w-min inline-block" >
+            <div className="left-0 w-min align-middle inline-block" >
               <IconButton  onClick={() => { setExpanded(!expanded); }}>
                 { expanded ? <UnfoldLess /> : <UnfoldMore /> }
               </IconButton>
             </div>
-            { expanded ? <></> : <div className="font-bold inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
-            <div className={`${expanded ? 'w-[calc(100%-2.5rem)]' : 'w-min'} inline-block top-auto bottom-0 right-0 left-auto`} >
+            { expanded ? <></> : <div className="align-middle inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
+            <div className={`${expanded ? 'w-[calc(100%-2.5rem)]' : 'w-min'} inline-block top-auto bottom-0 right-0 left-auto align-middle`} >
               <div className="workspace-entry-buttons">
 
               <Switch

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -14,7 +14,9 @@ import { motion } from "framer-motion";
 
 import "react-toggle/style.css";
 import "./css/workspace.css";
-import { IconButton, Switch } from "@mui/material";
+import { Collapse, IconButton, Switch } from "@mui/material";
+import { UnfoldLess, UnfoldMore } from "@mui/icons-material";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
 
 /** Fetches courses */
 function getCourse(
@@ -142,6 +144,9 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
 
   const state = useContext(AppState);
 
+  const [ expanded, setExpanded ] = useState(true);
+  const [ animParent, _ ] = useAutoAnimate();
+
   let className = "workspace-entry";
   className += course.locked
     ? " workspace-entry-locked"
@@ -163,7 +168,16 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
           >
-            <div className="workspace-entry-buttons">
+          <div className={`relative flex w-full justify-between`} ref={animParent} >
+            {expanded ? <div /> : <></>}
+            <div className="flex left-0 grow flex-initial" >
+              <IconButton  onClick={() => { setExpanded(!expanded); }}>
+                { expanded ? <UnfoldLess /> : <UnfoldMore /> }
+              </IconButton>
+              { expanded ? <></> : <div className="font-bold flex items-center overflow-clip w-0 flex-grow whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
+            </div>
+            <div className={`workspace-entry-buttons${expanded ? '' : '-collapsed'} right-0`} >
+
               <Switch
                 color="warning"
                 checked={course.enabled}
@@ -194,6 +208,8 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
                 <Delete />
               </IconButton>
             </div>
+          </div>
+          <Collapse in={expanded}>
             <div className="workspace-entry-content">
               <div className="workspace-entry-info">
                 <p>
@@ -222,7 +238,9 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
                 <SectionDropdown course={course} />
               </div>
             </div>
-          </div>
+          </Collapse>
+        </div>
+
         )}
       </Draggable>
       <Modal isOpen={infoModalOpen} onClose={() => setInfoModalOpen(false)}>

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -175,7 +175,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
                 { expanded ? <UnfoldLess /> : <UnfoldMore /> }
               </IconButton>
             </div>
-            { expanded ? <></> : <div className="align-middle inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap">{course.courseData.number}: {course.courseData.name}</div> }
+            { expanded ? <></> : <div className="align-middle inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap"><span className="font-bold">{course.courseData.number}</span> {course.courseData.name}</div> }
             <div className={`${expanded ? 'w-[calc(100%-2.5rem)]' : 'w-min'} inline-block top-auto bottom-0 right-0 left-auto align-middle`} >
               <div className="workspace-entry-buttons">
 

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -145,7 +145,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
   const state = useContext(AppState);
 
   const [ expanded, setExpanded ] = useState(true);
-  const [ collapseAnimation, __ ] = useAutoAnimate();
+  const [ animEntryTools, __ ] = useAutoAnimate();
 
   let className = "workspace-entry";
   className += course.locked
@@ -168,13 +168,13 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
           >
-          <div className={`relative w-full whitespace-nowrap`} ref={collapseAnimation} >
+          <div className={`relative w-full whitespace-nowrap`} ref={animEntryTools} >
             <div className="left-0 w-min align-middle inline-block" >
               <IconButton  onClick={() => { setExpanded(!expanded); }}>
                 { expanded ? <UnfoldLess /> : <UnfoldMore /> }
               </IconButton>
             </div>
-            { expanded ? <></> : <div className="align-middle inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-auto whitespace-nowrap"><span className="font-bold">{course.courseData.number}</span> {course.courseData.name}</div> }
+            { expanded ? <></> : <div className="align-middle inline-block max-w-[calc(100%-11rem)] items-center overflow-clip w-full whitespace-nowrap"><span className="font-bold">{course.courseData.number}</span> {course.courseData.name}</div> }
             <div className={`${expanded ? 'w-[calc(100%-2.5rem)]' : 'w-min'} inline-block top-auto bottom-0 right-0 left-auto align-middle`} >
               <div className="workspace-entry-buttons">
 
@@ -210,7 +210,7 @@ function WorkspaceEntry(props: WorkspaceEntryProps) {
             </div>
             </div>
           </div>
-          <Collapse in={expanded}>
+          <Collapse in={expanded} className="w-full">
             <div className="workspace-entry-content">
               <div className="workspace-entry-info">
                 <p>

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -106,13 +106,11 @@ li {
 .workspace-entry {
   display: flex;
   flex-direction: column;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-bottom: 16px;
   align-items: center;
   border: 1px solid lightgrey;
   border-radius: 4px;
   margin-bottom: 2em;
+  @apply p-2;
 }
 
 .workspace-entry-enabled {
@@ -160,6 +158,7 @@ li {
   column-gap: 1.5em;
   align-items: center;
   width: 100%;
+  @apply p-2 pt-0;
 }
 
 .workspace-entry-info > p {

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -141,6 +141,10 @@ li {
   width: 100%;
 }
 
+.workspace-entry-buttons-collapsed {
+  @apply flex grow-0 justify-end
+}
+
 .workspace-entry-toggle .react-toggle-track {
   border-radius: 20px;
 }

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -134,13 +134,8 @@ li {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  position: relative;
+  /* position: relative; */
   /* top: -12px; */
-  width: 100%;
-}
-
-.workspace-entry-buttons-collapsed {
-  @apply flex grow-0 justify-end
 }
 
 .workspace-entry-toggle .react-toggle-track {


### PR DESCRIPTION
Hi, I'm an incoming prefrosh and someone introduced me to this site. Has been super helpful for figuring out the whole course system! 

One minor thing was I sometimes had to scroll up and down a bunch to play with classes lower down and then see the results on the calendar. I figured it would be helpful to have a little collapse button would help with this (dragging stuff around is great but can get tiresome).

Felt like doing some soydevvery last night (was procrastinating on going to bed) so I just wrote it. Not sure if you take PRs but one is  👍 

Live demo https://caltech-dev-ten.vercel.app/

What it looks like: 

https://github.com/rchalamala/caltech.dev/assets/25516241/724192fc-1e24-4eae-ba85-3feb456733fb



Feel free to move things around, whatever, obviously