### PR TITLE
Recent PR bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **caltech.dev**, a purely client-side React SPA for Caltech course scheduling. There is no backend, no database, and no external services required.
+
+### Tech stack
+- React 18 + TypeScript + Vite 7 (dev server on port 3000)
+- Tailwind CSS + MUI + Emotion
+- Deployed to Cloudflare Pages/Workers via Wrangler
+
+### Running the app
+- `npm start` — starts the Vite dev server on port 3000 with HMR
+- `npm run build` — runs `tsc` then `vite build` (output in `dist/`)
+- `npm run dev` — runs Wrangler local dev (Cloudflare Workers emulation); not required for standard development
+
+### Lint / test
+- ESLint is listed as a devDependency but **no `.eslintrc` or `eslint.config.*` file exists** in the repo, so `npx eslint` will error about missing config. Type checking is done via `tsc` as part of `npm run build`.
+- There are no automated tests in the repo.
+
+### Data
+- Course data lives as static JSON files in `src/data/` covering terms FA2022 through SP2026. No API calls are made.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,25 @@
 
       gtag('config', 'G-61TJYY82J2');
     </script>
+    <script type="text/javascript">
+      // Restore GitHub Pages SPA redirects like `/?/fa2023` before React boots.
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(
+            null,
+            "",
+            l.pathname.slice(0, -1) + decoded + l.hash,
+          );
+        }
+      })(window.location);
+    </script>
     <link rel="manifest" href="/manifest.json" />
     <meta property="og:title" content="caltech.dev: Caltech Course Scheduling Simplified" />
     <meta property="og:site_name" content="caltech.dev" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,8 +6852,10 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore GitHub Pages SPA redirect-recovery script to fix deep linking after Vite migration.

The Vite migration in PR #109 inadvertently removed the `spa-github-pages` query-to-path script from `index.html`. This script is crucial for GitHub Pages to correctly handle deep links (e.g., `/?/fa2023` redirects to `/fa2023`) before the client-side application initializes, ensuring the app reads the correct route.

---
<p><a href="https://cursor.com/agents/bc-5f60ec3d-b53f-40b7-bef4-11a9e1f77882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f60ec3d-b53f-40b7-bef4-11a9e1f77882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->