### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a React + TypeScript SPA (Vite) for Caltech course scheduling, deployed to Cloudflare Workers. No backend or database services are required.
+
+### Running the app
+
+- `npm start` — starts the Vite dev server on port 3000 (hot reloading enabled).
+- `npm run build` — runs `tsc && vite build`; outputs to `dist/`.
+- `npm run dev` — runs Cloudflare Wrangler local dev (requires a prior build).
+
+### Linting
+
+- ESLint is listed as a devDependency but **no `.eslintrc` or `eslint.config.*` file** exists in the repo. Running `npx eslint` will fail with "couldn't find a configuration file." Type checking via `npx tsc --noEmit` is the primary static analysis tool.
+
+### Testing
+
+- There is no test framework or test suite configured in this project. Validation is done via `tsc --noEmit` (type checking) and manual testing in the browser.
+
+### Term/year routing
+
+- The app uses URL path segments for term selection (e.g., `/wi2026`, `/sp2026`, `/fa2025`). The default route loads the latest term.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,8 +6852,10 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud development instructions for this codebase.

### What's included

- Development environment documentation for future cloud agents
- Notes on running the app (`npm start` on port 3000), building (`npm run build`), type checking (`npx tsc --noEmit`), and the absence of an ESLint config
- Term/year URL routing documentation

### Environment verified

| Check | Status |
|-------|--------|
| `npm install` | Pass |
| `npx tsc --noEmit` | Pass |
| `npm run build` | Pass |
| `npm start` (Vite dev server, port 3000) | Pass |
| Manual browser testing (course search, add, calendar view) | Pass |

### Update script

`npm install` — minimal, idempotent dependency refresh.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcc5e1d1-b3dd-41c1-b120-04b3c33abbbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcc5e1d1-b3dd-41c1-b120-04b3c33abbbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

